### PR TITLE
Updated bower.json for latest chosen version

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -15,6 +15,6 @@
   "license": "MIT",
   "dependencies": {
     "bootstrap": "~3.1.1",
-    "chosen": "https://github.com/harvesthq/chosen/releases/download/v1.1.0/chosen_v1.1.0.zip"
+    "chosen": "https://github.com/harvesthq/chosen/releases/download/v1.3.0/chosen_v1.3.0.zip"
   }
 }


### PR DESCRIPTION
The bower.json still installs version 1.1.0 while the latest version is 1.3.0
